### PR TITLE
Added two methods in obcore/base/tools which read a line from an istream

### DIFF
--- a/obcore/base/tools.cpp
+++ b/obcore/base/tools.cpp
@@ -182,7 +182,37 @@ int serializePBM(const char* szFilename, void* pvBuffer, unsigned int nWidth, un
   return 1;
 }
 
+/**@brief Load one line from istream source and convert it into double
+ *
+ * @param source istream reference (ifstream, sstream, ...)
+ * @return computed double value
+ */
+double getDoubleLine(std::istream& source)
+{
+  std::string lineVar;
+  std::getline(source, lineVar);
+  if(!lineVar.size())
+    return NAN;
+  else
+  {
+    return std::strtod(lineVar.c_str(), NULL);
+  }
+}
 
+/**@brief Load one line from istream source and convert it into integer
+ *
+ * @param source istream reference (ifstream, sstream, ...)
+ * @return computed integer value
+ */
+int getIntLine(std::istream& source)
+{
+  std::string lineVar;
+  std::getline(source, lineVar);
+  if(!lineVar.size())
+    return NAN;
+  else
+    return std::atoi(lineVar.c_str());
+}
 //#include "jpeglib.h"
 //#include <string.h>
 //

--- a/obcore/base/tools.h
+++ b/obcore/base/tools.h
@@ -1,6 +1,8 @@
 #ifndef TOOLS_H__
 #define TOOLS_H__
 
+#include <istream>
+
 namespace obvious
 {
 
@@ -11,6 +13,10 @@ int serializePPM(const char* szFilename, void* pvBuffer, unsigned int nWidth, un
 int serializePGM(const char* szFilename, void* pvBuffer, unsigned int nWidth, unsigned int nHeight, bool bInc);
 
 int serializePBM(const char* szFilename, void* pvBuffer, unsigned int nWidth, unsigned int nHeight, bool bInc = 1);
+
+double getDoubleLine(std::istream& source);
+
+int getIntLine(std::istream& source);
 
 }
 

--- a/obvision/reconstruct/grid/TsdGrid.h
+++ b/obvision/reconstruct/grid/TsdGrid.h
@@ -34,6 +34,10 @@ enum EnumTsdGridPartitionIdentifier{ UNINITIALIZED = 0,
   EMPTY = 1,
   CONTENT = 2};
 
+enum EnumTsdGridLoadSource{ FILE = 0,
+  STRING = 1
+};
+
 /**
  * @class TsdGrid
  * @brief Grid on the basis of true signed distance functions
@@ -57,7 +61,7 @@ enum EnumTsdGridPartitionIdentifier{ UNINITIALIZED = 0,
    * Loads the grid data out of a given file. File has to be correct it is not being checked.
    * @param[in] path path to the data file
    */
-  TsdGrid(const std::string& path);
+  TsdGrid(const std::string& data, const EnumTsdGridLoadSource source = FILE);
 
   /**
    * Destructor


### PR DESCRIPTION
source (stringstream, fstream, ..) and convert it into double, or int.
These methods are used in the tsd grid to load data from an already
recorded map.