### PR TITLE
ransac error metric is calculated for all points, not only for inliers

### DIFF
--- a/obvision/ransacMatching/RansacMatching.cpp
+++ b/obvision/ransacMatching/RansacMatching.cpp
@@ -327,9 +327,10 @@ obvious::Matrix RansacMatching::match(const obvious::Matrix* M,  const bool* mas
 
           flann::SearchParams p(-1, 0.0);
           _index->knnSearch(query, indices, dists, 1, p);
+          err += dists[0][0];
           if(dists[0][0] < _epsSqr)
           {
-            err += dists[0][0];
+            //err += dists[0][0];
             cntMatch++;
           }
         }
@@ -339,7 +340,7 @@ obvious::Matrix RansacMatching::match(const obvious::Matrix* M,  const bool* mas
         if(cntMatch == 0)
           continue;
 
-        err /= cntMatch;
+        //err /= cntMatch;
 
         if(cntMatch > cntBest)
         {


### PR DESCRIPTION
Hallo Herry May,

die quadratische Abweichung über alle Punkte zu berechnen erzielt bei mir bessere Ergebnisse im Mapping. Wenn Sie möchten können Sie es ja mal übernehmen.

Viele Grüße

Markus