### PR TITLE
Ransac: Clipping of the control set to remove outliers according to rotation.

### DIFF
--- a/obvision/ransacMatching/RansacMatching.cpp
+++ b/obvision/ransacMatching/RansacMatching.cpp
@@ -303,9 +303,7 @@ obvious::Matrix RansacMatching::match(const obvious::Matrix* M,  const bool* mas
         flann::Matrix<double> dists(new double[1], 1, 1);
         double err = 0;
 
-
         int clippedBeams = (int) (phi / resolution);
-
         for(unsigned int s = 0; s < STemp.getCols(); s++)
         {
           if( idxControl[s] < (unsigned int) max(0, clippedBeams) || idxControl[s] > min(pointsInS, pointsInS+clippedBeams) )

--- a/obvision/ransacMatching/RansacMatching.cpp
+++ b/obvision/ransacMatching/RansacMatching.cpp
@@ -83,7 +83,6 @@ obvious::Matrix* RansacMatching::pickControlSet(const obvious::Matrix* M, vector
     sizeControlSet = idxValid.size();
   }
   obvious::Matrix* C = new obvious::Matrix(3, _sizeControlSet);
-  //vector<unsigned int> idxControl;
   vector<unsigned int> idxTemp = idxValid;
   unsigned int ctr = 0;
   while(idxControl.size() < sizeControlSet)

--- a/obvision/ransacMatching/RansacMatching.cpp
+++ b/obvision/ransacMatching/RansacMatching.cpp
@@ -74,7 +74,7 @@ void RansacMatching::initKDTree(const obvious::Matrix* M, vector<unsigned int> v
   obvious::System<double>::deallocate(mData);
 }
 
-obvious::Matrix* RansacMatching::pickControlSet(const obvious::Matrix* M, vector<unsigned int> idxValid)
+obvious::Matrix* RansacMatching::pickControlSet(const obvious::Matrix* M, vector<unsigned int> idxValid, vector<unsigned int> &idxControl)
 {
   unsigned int sizeControlSet = _sizeControlSet;
   if((idxValid.size()) < sizeControlSet)
@@ -83,7 +83,7 @@ obvious::Matrix* RansacMatching::pickControlSet(const obvious::Matrix* M, vector
     sizeControlSet = idxValid.size();
   }
   obvious::Matrix* C = new obvious::Matrix(3, _sizeControlSet);
-  vector<unsigned int> idxControl;
+  //vector<unsigned int> idxControl;
   vector<unsigned int> idxTemp = idxValid;
   unsigned int ctr = 0;
   while(idxControl.size() < sizeControlSet)
@@ -190,7 +190,8 @@ obvious::Matrix RansacMatching::match(const obvious::Matrix* M,  const bool* mas
 
   initKDTree(M, idxMValid);
 
-  obvious::Matrix* Control = pickControlSet(S, idxSValid);
+  vector<unsigned int> idxControl;  //represents the indices of points used for Control in S.
+  obvious::Matrix* Control = pickControlSet(S, idxSValid, idxControl);
 
   LOGMSG(DBG_DEBUG, "Valid points in scene: " << idxSValid.size() << ", Control set: " << Control->getCols());
 
@@ -302,8 +303,15 @@ obvious::Matrix RansacMatching::match(const obvious::Matrix* M,  const bool* mas
         flann::Matrix<int> indices(new int[1], 1, 1);
         flann::Matrix<double> dists(new double[1], 1, 1);
         double err = 0;
+
+
+        int clippedBeams = (int) (phi / resolution);
+
         for(unsigned int s = 0; s < STemp.getCols(); s++)
         {
+          if( idxControl[s] < (unsigned int) max(0, clippedBeams) || idxControl[s] > min(pointsInS, pointsInS+clippedBeams) )
+            continue; // points that won't have a corresponding point due to rotation are ignored for the metric
+
           q[0] = STemp(0, s);
           q[1] = STemp(1, s);
           flann::Matrix<double> query(q, 1, 2);
@@ -323,7 +331,7 @@ obvious::Matrix RansacMatching::match(const obvious::Matrix* M,  const bool* mas
         if(cntMatch == 0)
           continue;
 
-        //err /= cntMatch;
+        err /= cntMatch;
 
         if(cntMatch > cntBest)
         {

--- a/obvision/ransacMatching/RansacMatching.h
+++ b/obvision/ransacMatching/RansacMatching.h
@@ -46,7 +46,7 @@ private:
   void initKDTree(const obvious::Matrix* M, vector<unsigned int> valid);
 
   // pick control set for RANSAC in-/outlier detection
-  obvious::Matrix* pickControlSet(const obvious::Matrix* M, vector<unsigned int> idxValid);
+  obvious::Matrix* pickControlSet(const obvious::Matrix* M, vector<unsigned int> idxValid, vector<unsigned int> &idxControl);
 
   // create look-up table for point to point intra-distance of a point set
   double** createLutIntraDistance(const obvious::Matrix* M, const bool* mask, int maxDist);


### PR DESCRIPTION
Hallo Herr May,

wie Sie in den Änderungen sehen können, werden für die Metrik nur noch Punkte verwendet, die nicht durch eine Rotation hinzugekommen sind bzw. eben schon auch im Model Scan existieren. Der Fehler am Anfang des Intel Datensatzes reduziert sich dadurch.

Leider habe ich immernoch extreme Probleme bei 10 Hz Abspielgeschwindigkeit, sobald wir in die zweite Runde kommen. Bei 5 Hz geht das besser. Eigentlich dachte ich dort schlägt die Registrierung nur fehl. Aber bei 5 Hz schafft die Registrierung es und es scheint, dass der Scanner am Anfang der zweiten Runde um 360 Grad gedreht wird, bevor es weiter geht. 5 Hz ist auch ungefähr die Geschwindigkeit des Mapping.

Wenn ich nur die Rotation vom Ransac übernehme, funktioniert das Mapping nicht. Selbst wenn der ICP 100 Icp Iterationen rechnet. 