### PR TITLE
Renamed the load sources of the tsd grid due to type errors.

### DIFF
--- a/obvision/reconstruct/grid/TsdGrid.cpp
+++ b/obvision/reconstruct/grid/TsdGrid.cpp
@@ -33,7 +33,7 @@ TsdGrid::TsdGrid(const std::string& data, const EnumTsdGridLoadSource source)
   std::ifstream inFile;
   std::stringstream ss;
 
-  if(source == FILE)
+  if(source == FILE_SOURCE)
   {
     inFile.open(data.c_str(), std::fstream::in);
     if(!inFile.is_open())
@@ -43,7 +43,7 @@ TsdGrid::TsdGrid(const std::string& data, const EnumTsdGridLoadSource source)
     }
     istream = &inFile;
   }
-  else if(source == STRING)
+  else if(source == STRING_SOURCE)
   {
     ss << data;
     LOGMSG(DBG_DEBUG, "loaded " << ss.str().size() << " characters into stringstream\n");
@@ -56,7 +56,7 @@ TsdGrid::TsdGrid(const std::string& data, const EnumTsdGridLoadSource source)
   if( (layoutGrid < 0) || (layoutPartition < 0) || (layoutGrid > 15) || (layoutPartition > 15) )
   {
     LOGMSG(DBG_ERROR, " error! Partition or Gridlayout invalid!\n");
-    if(source == FILE)
+    if(source == FILE_SOURCE)
       inFile.close();
     std::exit(3);
   }
@@ -101,7 +101,7 @@ TsdGrid::TsdGrid(const std::string& data, const EnumTsdGridLoadSource source)
       }
     }
   }
-  if(source == FILE)
+  if(source == FILE_SOURCE)
   {
   inFile.close();
   if(inFile.is_open())

--- a/obvision/reconstruct/grid/TsdGrid.h
+++ b/obvision/reconstruct/grid/TsdGrid.h
@@ -34,8 +34,8 @@ enum EnumTsdGridPartitionIdentifier{ UNINITIALIZED = 0,
   EMPTY = 1,
   CONTENT = 2};
 
-enum EnumTsdGridLoadSource{ FILE = 0,
-  STRING = 1
+enum EnumTsdGridLoadSource{ FILE_SOURCE = 0,
+  STRING_SOURCE = 1
 };
 
 /**
@@ -61,7 +61,7 @@ public:
    * Loads the grid data out of a given file. File has to be correct it is not being checked.
    * @param[in] path path to the data file
    */
-  TsdGrid(const std::string& data, const EnumTsdGridLoadSource source = FILE);
+  TsdGrid(const std::string& data, const EnumTsdGridLoadSource source = FILE_SOURCE);
 
   /**
    * Destructor


### PR DESCRIPTION
Renamed enums in the tsd grid due to name conflicts (obvious::FILE, std::FILE).