### PR TITLE
bugfix in getPiCorrectedAngle(); wrong sign of M_PI

### DIFF
--- a/obcore/math/mathbase.h
+++ b/obcore/math/mathbase.h
@@ -234,7 +234,7 @@ namespace obvious {
    */
   static inline double getPiCorrectedAngle(const double angle) {
     double correctedAngle = angle;
-    if (correctedAngle < M_PI)
+    if (correctedAngle < -M_PI)
       correctedAngle += 2*M_PI;
     else if (correctedAngle > M_PI)
       correctedAngle -= 2*M_PI;


### PR DESCRIPTION
If this is really a bug, we should fix it... 